### PR TITLE
Fix race condition in AssetManager

### DIFF
--- a/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
@@ -11,7 +11,7 @@ import Photos
 // MARK: - PHPhotoLibraryChangeObserver & Sync
 extension AssetsManager: PHPhotoLibraryChangeObserver {
     
-    func synchronizeAlbums(changeInstance: PHChange) -> [IndexSet] {
+    private func synchronizeAlbums(changeInstance: PHChange) -> [IndexSet] {
         
         // updated index set
         var updatedIndexSets = [IndexSet]()
@@ -59,9 +59,9 @@ extension AssetsManager: PHPhotoLibraryChangeObserver {
         return updatedIndexSets
     }
     
-    func synchronizeAssets(updatedAlbumIndexSets: [IndexSet], fetchMapBeforeChanges: [String: PHFetchResult<PHAsset>], changeInstance: PHChange) {
+    private func synchronizeAssets(updatedAlbumIndexSets: [IndexSet], fetchMapBeforeChanges: [String: PHFetchResult<PHAsset>], changeInstance: PHChange) {
         
-        var updatedIndexSets = updatedAlbumIndexSets
+        let updatedIndexSets = updatedAlbumIndexSets
         
         // notify changes of assets
         for (section, albums) in fetchedAlbumsArray.enumerated() {
@@ -192,13 +192,16 @@ extension AssetsManager: PHPhotoLibraryChangeObserver {
             logw("Does not have access to photo library.")
             return
         }
-        let fetchMapBeforeChanges = fetchMap
-        let updatedAlbumIndexSets = synchronizeAlbums(changeInstance: changeInstance)
-        synchronizeAssets(
-            updatedAlbumIndexSets: updatedAlbumIndexSets,
-            fetchMapBeforeChanges: fetchMapBeforeChanges,
-            changeInstance: changeInstance
-        )
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let fetchMapBeforeChanges = self.fetchMap
+            let updatedAlbumIndexSets = self.synchronizeAlbums(changeInstance: changeInstance)
+            self.synchronizeAssets(
+                updatedAlbumIndexSets: updatedAlbumIndexSets,
+                fetchMapBeforeChanges: fetchMapBeforeChanges,
+                changeInstance: changeInstance
+            )
+        }
     }
     
     public func removedIndexPaths(from newAlbums: [PHAssetCollection], oldAlbums: [PHAssetCollection], section: Int) -> (indexPaths: [IndexPath], albums: [PHAssetCollection]) {


### PR DESCRIPTION
**Background:**

A crash in AssetsManager happens with the following sequence:
1. Make sure there are photos on iCloud not yet synced to iPad
2. Use asset picker to choose an un-synced photo
3. Crash happens in AssetsManager.synchronizeAssets

**Root cause:**

AssetsManager is a singleton, its state is accessed and mutated most of the time on the main queue: `AssetsManager.shared` is mostly used in view controllers.

However, AssetsManager is also an observer of photo library changes. It implements photoLibraryDidChange callback, and access its state on the `PHChange-queue` as shown in the screenshot. This cause a race condition on the state, specifically on `fetchedAlbumsArray` and `sortedAlbumsArray`.

One way to trigger photoLibraryDidChange callback is by selecting an un-synced photo. Hence the above steps to reproduce.

![image](https://user-images.githubusercontent.com/6576395/152771722-0836cc14-5c0e-4dbb-a7c3-839292c00c8c.png)

**Fix:**

In photoLibraryDidChange implementation, access state on the main queue.

**Test:**

After the change, no more crash observed by following the above steps.