### PR TITLE
fix: avoid deadlock in main queue

### DIFF
--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -113,10 +113,8 @@ extension AssetsManager {
     
     open func notifySubscribers(_ action: @escaping ((AssetsManagerDelegate) -> Void), condition: Bool = true) {
         if condition {
-            DispatchQueue.main.sync {
-                for subscriber in self.subscribers {
-                    action(subscriber)
-                }
+            for subscriber in subscribers {
+                action(subscriber)
             }
         }
     }


### PR DESCRIPTION
**Analysis**

`notifySubscribers` is only called by `synchronizeAlbums` and `synchronizeAssets`.

After this PR https://github.com/screeningeagledreamlab/AssetsPickerViewController/pull/3, `synchronizeAlbums` and `synchronizeAssets` are only called from the main queue to avoid race condition.

Therefore, `notifySubscribers` is already called on the main queue. Hence within `notifySubscribers`, calling `DispatchQueue.main.sync` will cause deadlock as shown in the screenshot.

![image](https://user-images.githubusercontent.com/6576395/153798177-82fea8c5-9449-439d-aa30-512dc951a9b8.png)

**Fix**
The fix is simply getting rid of `DispatchQueue.main.sync` within `notifySubscribers`. After this, no crash is observed when `synchronizeAlbums` and `synchronizeAssets` are called.

In fact, I think dispatching a task synchronously to the main queue should always be done sparingly. It is highly likely the current queue is already main queue, dispatching a task synchronously to a serial queue from that queue is recipe for deadlock.